### PR TITLE
Refactor ConfirmUserRegister return type and logic

### DIFF
--- a/BabyCare/BabyCare.Contract.Services/Interface/IUserService.cs
+++ b/BabyCare/BabyCare.Contract.Services/Interface/IUserService.cs
@@ -17,7 +17,7 @@ namespace BabyCare.Contract.Services.Interface
         Task<ApiResult<UserLoginResponseModel>> UserLoginGoogle(UserLoginGoogleRequest request);
 
         Task<ApiResult<object>> UserRegister(UserRegisterRequestModel request);
-        Task<ApiResult<object>> ConfirmUserRegister(ConfirmUserRegisterRequest request);
+        Task<ApiResult<UserLoginResponseModel>> ConfirmUserRegister(ConfirmUserRegisterRequest request);
 
         Task<ApiResult<object>> ForgotPassword(ForgotPasswordRequest request);
         Task<ApiResult<object>> ResetPassword(ResetPasswordRequestModel request);


### PR DESCRIPTION
Changed ConfirmUserRegister return type in IUserService and UserService from Task<ApiResult<object>> to Task<ApiResult<UserLoginResponseModel>>. Updated error responses to return ApiErrorResult<UserLoginResponseModel>. Added logic to generate and store refresh and access tokens upon successful email confirmation. Created and populated UserLoginResponseModel with tokens and expiry times. Method now returns ApiSuccessResult<UserLoginResponseModel> with the response model and a success message.