### PR TITLE
Retain existing images if request image is null

### DIFF
--- a/BabyCare/BabyCare.Services/Service/AppointmentTemplateService.cs
+++ b/BabyCare/BabyCare.Services/Service/AppointmentTemplateService.cs
@@ -194,6 +194,8 @@ namespace BabyCare.Services.Service
             {
                 return new ApiErrorResult<object>("Status is not correct.", System.Net.HttpStatusCode.BadRequest);
             }
+            var existingImage = existingItem.Image;
+
             _mapper.Map(request, existingItem);
             existingItem.Status = (int)request.Status;
             existingItem.LastUpdatedTime = DateTime.Now;
@@ -201,6 +203,11 @@ namespace BabyCare.Services.Service
             if (request.Image != null)
             {
                 existingItem.Image = await ImageHelper.Upload(request.Image);
+            }
+            else
+            {
+                existingItem.Image = existingImage;
+
             }
             await repo.UpdateAsync(existingItem);
             await repo.SaveAsync();

--- a/BabyCare/BabyCare.Services/Service/MembershipPackageService.cs
+++ b/BabyCare/BabyCare.Services/Service/MembershipPackageService.cs
@@ -212,7 +212,7 @@ namespace BabyCare.Services.Service
             {
                 return new ApiErrorResult<object>("Package is not existed.");
             }
-
+            var existingImage = existingItem.ImageUrl;
             _mapper.Map(request, existingItem);
             existingItem.Price = (request.OriginalPrice - (request.OriginalPrice * (request.Discount / 100)));
             if (existingItem.Price < 0)
@@ -225,6 +225,11 @@ namespace BabyCare.Services.Service
             {
                 existingItem.ImageUrl = await ImageHelper.Upload(request.ImageUrl);
             }
+            else
+            {
+                existingItem.ImageUrl = existingImage;
+            }
+            
             await repo.UpdateAsync(existingItem);
             await repo.SaveAsync();
 

--- a/BabyCare/BabyCare.Services/Service/UserService.cs
+++ b/BabyCare/BabyCare.Services/Service/UserService.cs
@@ -420,8 +420,19 @@ namespace BabyCare.Contract.Services.Implements
             {
                 return new ApiErrorResult<object>("Gender is not valid.", System.Net.HttpStatusCode.BadRequest);
             }
+            var existingImage = existingUser.Image;
+
             // Update user profile by mapper
             _mapper.Map(request, existingUser);
+
+            if (request.Image != null)
+            {
+                existingUser.Image = await ImageHelper.Upload(request.Image);
+            }
+            else
+            {
+                existingUser.Image = existingImage;
+            }
             var result = await _userManager.UpdateAsync(existingUser);
             if (!result.Succeeded)
             {
@@ -625,13 +636,21 @@ namespace BabyCare.Contract.Services.Implements
             {
                 return new ApiErrorResult<object>("Gender is not valid.", System.Net.HttpStatusCode.BadRequest);
             }
+            var existingImage = existingUser.Image;
 
             // Update user profile by mapper
             _mapper.Map(request, existingUser);
             existingUser.LastUpdatedTime = DateTime.Now;
             existingUser.LastUpdatedBy = Guid.Parse(_contextAccessor.HttpContext?.User?.FindFirst("userId")?.Value);
             existingUser.Gender = request.Gender;
-
+            if (request.Image != null)
+            {
+                existingUser.Image = await ImageHelper.Upload(request.Image);
+            }
+            else
+            {
+                existingUser.Image = existingImage;
+            }
             var result = await _userManager.UpdateAsync(existingUser);
             if (!result.Succeeded)
             {


### PR DESCRIPTION
In AppointmentTemplateService.cs, MembershipPackageService.cs, and UserService.cs, changes ensure that existing images are retained if the request image or image URL is null. This is done by storing the existing image in a variable `existingImage` before mapping the request to the existing item and then conditionally setting the image.