### PR TITLE
Add Reason property to AppointmentResponseModel

### DIFF
--- a/BabyCare/BabyCare.ModelViews/AppointmentModelViews/Response/AppointmentResponseModel.cs
+++ b/BabyCare/BabyCare.ModelViews/AppointmentModelViews/Response/AppointmentResponseModel.cs
@@ -54,6 +54,7 @@ namespace BabyCare.ModelViews.AppointmentModelViews.Response
         public DateTime? AssignedTime { get; set; }
         public Guid AssignedBy { get; set; }
         public string? Description { get; set; }
+        public string Reason { get; set; }
     }
     public class ChildModelViewAddeRecords : ChildModelView.ChildModelView
     {


### PR DESCRIPTION
A new property `Reason` of type `string` has been added to the `AppointmentResponseModel` class within the
`BabyCare.ModelViews.AppointmentModelViews.Response` namespace.