### PR TITLE
Add endpoint to retrieve all admin appointments

### DIFF
--- a/BabyCare/BabyCare.API/Controllers/AppointmentsController.cs
+++ b/BabyCare/BabyCare.API/Controllers/AppointmentsController.cs
@@ -244,6 +244,19 @@ namespace BabyCare.API.Controllers
                 return BadRequest(new BabyCare.Core.APIResponse.ApiErrorResult<BasePaginatedList<EmployeeResponseModel>>(ex.Message));
             }
         }
+        [HttpGet("get-all-by-admin")]
+        public async Task<IActionResult> GetAll()
+        {
+            try
+            {
+                var result = await _appointmentService.GetAllByAdmin();
+                return Ok(result);
+            }
+            catch (Exception ex)
+            {
+                return BadRequest(new BabyCare.Core.APIResponse.ApiErrorResult<BasePaginatedList<EmployeeResponseModel>>(ex.Message));
+            }
+        }
 
         [HttpPost("change-doctor-appointment")]
         public async Task<IActionResult> ChangeDoctorAppointment(ChangeDoctorAppointmentRequest request)

--- a/BabyCare/BabyCare.Contract.Services/Interface/IAppointmentService.cs
+++ b/BabyCare/BabyCare.Contract.Services/Interface/IAppointmentService.cs
@@ -39,6 +39,7 @@ namespace BabyCare.Contract.Services.Interface
         Task<ApiResult<AvailableSlotResponseModel>> GetSlotAvailable(DateTime date);
 
         Task<ApiResult<object>> ChangeDoctorAppointment(ChangeDoctorAppointmentRequest request);
+        Task<ApiResult<List<AppointmentResponseModel>>> GetAllByAdmin();
 
     }
 }


### PR DESCRIPTION
Added a new `GetAll` endpoint in `AppointmentsController` to fetch all appointments for the admin. Introduced `GetAllByAdmin` method in `IAppointmentService` interface and implemented it in `AppointmentService`. The method retrieves and maps detailed information about appointments, users, doctors, appointment templates, and children, returning the data wrapped in an `ApiSuccessResult`.