### PR TITLE
Add unblock feedback endpoint and set default user gender

### DIFF
--- a/BabyCare/BabyCare.API/Controllers/FeedbackController.cs
+++ b/BabyCare/BabyCare.API/Controllers/FeedbackController.cs
@@ -130,5 +130,19 @@ namespace BabyCare.API.Controllers
             }
 
         }
+        [HttpPut("unban-feedback")]
+        public async Task<IActionResult> UnBlockFeedbackAsync([FromBody] BanFeedbackRequest request)
+        {
+            try
+            {
+                var result = await _feedbackService.UnBlockFeedbackAsync(request);
+                return Ok(result);
+            }
+            catch (Exception ex)
+            {
+                return BadRequest(new BabyCare.Core.APIResponse.ApiErrorResult<object>(ex.Message));
+            }
+
+        }
     }
 }

--- a/BabyCare/BabyCare.Services/Service/UserService.cs
+++ b/BabyCare/BabyCare.Services/Service/UserService.cs
@@ -1007,7 +1007,8 @@ namespace BabyCare.Contract.Services.Implements
                 FullName = $"{request.Family_name} {request.Given_name} {request.Name}",
                 Image = request.Picture,
                 UserName = await _generateGGUsernameAsync(),
-                Status = (int)UserStatus.Active
+                Status = (int)UserStatus.Active,
+                Gender = 0
             };
 
             var addUserStatus = await _userManager.CreateAsync(userEntity);


### PR DESCRIPTION
Added UnBlockFeedbackAsync endpoint in FeedbackController to handle unblocking feedback via HTTP PUT requests. Updated UserService to initialize the Gender property with a default value of 0 during user creation, ensuring consistent user data.